### PR TITLE
Improve mapping of operative SMV data to pay elements

### DIFF
--- a/BonusCalcListener.Tests/Gateway/PayElementGatewayTests.cs
+++ b/BonusCalcListener.Tests/Gateway/PayElementGatewayTests.cs
@@ -148,6 +148,7 @@ namespace BonusCalcListener.Tests.Gateway
 
             var timesheet = new Timesheet
             {
+                Id = "123456/2021-10-18",
                 Week = week,
                 Operative = operative,
                 PayElements = new List<PayElement>()

--- a/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
+++ b/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
@@ -86,7 +86,7 @@ namespace BonusCalcListener.Tests.UseCase
             return timesheet;
         }
 
-        public static IEnumerable<PayElement> GeneratePayElements()
+        public static List<PayElement> GeneratePayElements()
         {
             var productivePayElementType = new PayElementType
             {
@@ -142,6 +142,7 @@ namespace BonusCalcListener.Tests.UseCase
                 EventData = new WorkOrderOperativeSmvData
                 {
                     WorkOrderId = "10003773",
+                    WorkOrderStatusCode = 50,
                     Address = "34 DeBeauvoir Square, London, N4 2FL",
                     StandardMinuteValue = 100,
                     OperativePrn = "4044",

--- a/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
+++ b/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
@@ -134,25 +134,25 @@ namespace BonusCalcListener.Tests.UseCase
 
         public static EntityEventSns ValidMessage()
         {
-            return new EntityEventSns
-            {
-                Id = Guid.NewGuid(),
-                EventType = RepairsEventTypes.WorkOrderUpdatedEvent,
-                DateTime = DateTime.Now,
-                EventData = new WorkOrderOperativeSmvData
-                {
-                    WorkOrderId = "10003773",
-                    WorkOrderStatusCode = 50,
-                    Address = "34 DeBeauvoir Square, London, N4 2FL",
-                    StandardMinuteValue = 100,
-                    OperativePrn = "4044",
-                    JobPercentage = 0.50d,
-                    ClosedTime = new DateTime(2021, 11, 09, 21, 28, 00)
-                }
-            };
+            return SnsMessage(RepairsStatusCodes.Completed);
+        }
+
+        public static EntityEventSns NoAccessMessage()
+        {
+            return SnsMessage(RepairsStatusCodes.NoAccess);
         }
 
         public static EntityEventSns CancelledMessage()
+        {
+            return SnsMessage(RepairsStatusCodes.Cancelled);
+        }
+
+        public static EntityEventSns UnknownMessage()
+        {
+            return SnsMessage(999);
+        }
+
+        private static EntityEventSns SnsMessage(int WorkOrderStatusCode)
         {
             return new EntityEventSns
             {
@@ -162,7 +162,7 @@ namespace BonusCalcListener.Tests.UseCase
                 EventData = new WorkOrderOperativeSmvData
                 {
                     WorkOrderId = "10003773",
-                    WorkOrderStatusCode = 30,
+                    WorkOrderStatusCode = WorkOrderStatusCode,
                     Address = "34 DeBeauvoir Square, London, N4 2FL",
                     StandardMinuteValue = 100,
                     OperativePrn = "4044",

--- a/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
+++ b/BonusCalcListener.Tests/UseCase/BonusCalcTestDataFactory.cs
@@ -151,5 +151,25 @@ namespace BonusCalcListener.Tests.UseCase
                 }
             };
         }
+
+        public static EntityEventSns CancelledMessage()
+        {
+            return new EntityEventSns
+            {
+                Id = Guid.NewGuid(),
+                EventType = RepairsEventTypes.WorkOrderUpdatedEvent,
+                DateTime = DateTime.Now,
+                EventData = new WorkOrderOperativeSmvData
+                {
+                    WorkOrderId = "10003773",
+                    WorkOrderStatusCode = 30,
+                    Address = "34 DeBeauvoir Square, London, N4 2FL",
+                    StandardMinuteValue = 100,
+                    OperativePrn = "4044",
+                    JobPercentage = 0.50d,
+                    ClosedTime = new DateTime(2021, 11, 09, 21, 28, 00)
+                }
+            };
+        }
     }
 }

--- a/BonusCalcListener.Tests/UseCase/PayElementMapperTests.cs
+++ b/BonusCalcListener.Tests/UseCase/PayElementMapperTests.cs
@@ -54,6 +54,9 @@ namespace BonusCalcListener.Tests.UseCase
             // Arrange
             var timesheet = _fixture.Create<Timesheet>();
             var evtData = _fixture.Create<WorkOrderOperativeSmvData>();
+            evtData.WorkOrderStatusCode = 50;
+            evtData.StandardMinuteValue = 300;
+            evtData.JobPercentage = 50;
             evtData.ClosedTime = new DateTime(2021, 11, 08, 14, 32, 01);
 
             // Act
@@ -61,15 +64,50 @@ namespace BonusCalcListener.Tests.UseCase
 
             // Assert
             result.TimesheetId.Should().Be(timesheet.Id);
-            result.Monday.Should().Be((decimal) (evtData.StandardMinuteValue * evtData.JobPercentage) / 60);
-            result.Tuesday.Should().Be(0);
-            result.Wednesday.Should().Be(0);
-            result.Thursday.Should().Be(0);
-            result.Friday.Should().Be(0);
-            result.Saturday.Should().Be(0);
-            result.Sunday.Should().Be(0);
-            result.Duration.Should().Be((decimal) (evtData.StandardMinuteValue * evtData.JobPercentage) / 60);
+            result.WorkOrder.Should().Be(evtData.WorkOrderId);
+            result.Address.Should().Be(evtData.Address);
+            result.Comment.Should().Be(evtData.Description);
             result.ClosedAt.Should().Be(evtData.ClosedTime);
+            result.Monday.Should().Be(2.5m);
+            result.Tuesday.Should().Be(0.0m);
+            result.Wednesday.Should().Be(0.0m);
+            result.Thursday.Should().Be(0.0m);
+            result.Friday.Should().Be(0.0m);
+            result.Saturday.Should().Be(0.0m);
+            result.Sunday.Should().Be(0.0m);
+            result.Duration.Should().Be(2.5m);
+            result.Value.Should().Be(150.0m);
+        }
+
+        [Test]
+        public void ShouldCreatePayElementWithZeroValue()
+        {
+            // Arrange
+            var timesheet = _fixture.Create<Timesheet>();
+            var evtData = _fixture.Create<WorkOrderOperativeSmvData>();
+            evtData.WorkOrderStatusCode = 1000;
+            evtData.StandardMinuteValue = 300;
+            evtData.JobPercentage = 50;
+            evtData.ClosedTime = new DateTime(2021, 11, 08, 14, 32, 01);
+
+            // Act
+            var result = _sut.BuildPayElement(evtData, timesheet);
+
+            // Assert
+            result.TimesheetId.Should().Be(timesheet.Id);
+            result.WorkOrder.Should().Be(evtData.WorkOrderId);
+            result.Address.Should().Be(evtData.Address);
+            result.Comment.Should().Be(evtData.Description);
+            result.ClosedAt.Should().Be(evtData.ClosedTime);
+            result.Monday.Should().Be(0.0m);
+            result.Tuesday.Should().Be(0.0m);
+            result.Wednesday.Should().Be(0.0m);
+            result.Thursday.Should().Be(0.0m);
+            result.Friday.Should().Be(0.0m);
+            result.Saturday.Should().Be(0.0m);
+            result.Sunday.Should().Be(0.0m);
+            result.Duration.Should().Be(0.0m);
+            result.Value.Should().Be(0.0m);
         }
 
         [SetUp]

--- a/BonusCalcListener/Boundary/WorkOrderOperativeSmvData.cs
+++ b/BonusCalcListener/Boundary/WorkOrderOperativeSmvData.cs
@@ -5,6 +5,7 @@ namespace BonusCalcListener.Boundary
     public class WorkOrderOperativeSmvData
     {
         public string WorkOrderId { get; set; }
+        public int WorkOrderStatusCode { get; set; }
         public string Address { get; set; }
 
         public string Description { get; set; }

--- a/BonusCalcListener/Gateway/Interfaces/IPayElementGateway.cs
+++ b/BonusCalcListener/Gateway/Interfaces/IPayElementGateway.cs
@@ -8,6 +8,6 @@ namespace BonusCalcListener.Gateway
 {
     public interface IPayElementGateway
     {
-        Task<IEnumerable<PayElement>> GetPayElementsByWorkOrderId(string workOrderId, int payElementType);
+        Task<List<PayElement>> GetPayElementsByWorkOrderId(string workOrderId, int payElementType);
     }
 }

--- a/BonusCalcListener/Gateway/PayElementGateway.cs
+++ b/BonusCalcListener/Gateway/PayElementGateway.cs
@@ -15,7 +15,7 @@ namespace BonusCalcListener.Gateway
             _context = context;
         }
 
-        public async Task<IEnumerable<PayElement>> GetPayElementsByWorkOrderId(string workOrderId, int payElementType)
+        public async Task<List<PayElement>> GetPayElementsByWorkOrderId(string workOrderId, int payElementType)
         {
             return await _context.PayElements
                 .Where(pe => pe.PayElementTypeId == payElementType)

--- a/BonusCalcListener/Infrastructure/BonusCalcContext.cs
+++ b/BonusCalcListener/Infrastructure/BonusCalcContext.cs
@@ -29,6 +29,9 @@ namespace BonusCalcListener.Infrastructure
                 .IsUnique();
 
             modelBuilder.Entity<Operative>()
+                .HasIndex(o => o.TradeId);
+
+            modelBuilder.Entity<Operative>()
                 .HasOne(o => o.Trade)
                 .WithMany(t => t.Operatives)
                 .HasForeignKey(o => o.TradeId);
@@ -40,6 +43,15 @@ namespace BonusCalcListener.Infrastructure
                 .HasOne(o => o.Scheme)
                 .WithMany(s => s.Operatives)
                 .HasForeignKey(o => o.SchemeId);
+
+            modelBuilder.Entity<Operative>()
+                .HasIndex(o => o.EmailAddress)
+                .IsUnique();
+
+            modelBuilder.Entity<Operative>()
+                .Property(o => o.Utilisation)
+                .HasPrecision(5, 4)
+                .HasDefaultValue(1.0);
 
             modelBuilder.Entity<PayBand>()
                 .Property(pb => pb.Id)
@@ -54,9 +66,15 @@ namespace BonusCalcListener.Infrastructure
                 .HasForeignKey(pb => pb.SchemeId);
 
             modelBuilder.Entity<PayElement>()
+                .HasIndex(pe => pe.TimesheetId);
+
+            modelBuilder.Entity<PayElement>()
                 .HasOne(pe => pe.Timesheet)
                 .WithMany(t => t.PayElements)
                 .HasForeignKey(t => t.TimesheetId);
+
+            modelBuilder.Entity<PayElement>()
+                .HasIndex(pe => pe.PayElementTypeId);
 
             modelBuilder.Entity<PayElement>()
                 .HasOne(pe => pe.PayElementType)
@@ -115,11 +133,27 @@ namespace BonusCalcListener.Infrastructure
                 .IsUnique();
 
             modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.NonProductive)
+                .HasDefaultValue(false);
+
+            modelBuilder.Entity<PayElementType>()
                 .Property(pet => pet.Productive)
                 .HasDefaultValue(false);
 
             modelBuilder.Entity<PayElementType>()
                 .Property(pet => pet.Adjustment)
+                .HasDefaultValue(false);
+
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.OutOfHours)
+                .HasDefaultValue(false);
+
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.Overtime)
+                .HasDefaultValue(false);
+
+            modelBuilder.Entity<PayElementType>()
+                .Property(pet => pet.Selectable)
                 .HasDefaultValue(false);
 
             modelBuilder.Entity<Scheme>()
@@ -136,8 +170,15 @@ namespace BonusCalcListener.Infrastructure
                 .HasDefaultValue(1.0);
 
             modelBuilder.Entity<Timesheet>()
+                .Property(t => t.Id)
+                .ValueGeneratedNever();
+
+            modelBuilder.Entity<Timesheet>()
                 .HasIndex(t => new { t.OperativeId, t.WeekId })
                 .IsUnique();
+
+            modelBuilder.Entity<Timesheet>()
+                .HasIndex(t => t.WeekId);
 
             modelBuilder.Entity<Timesheet>()
                 .HasOne(t => t.Operative)
@@ -148,6 +189,11 @@ namespace BonusCalcListener.Infrastructure
                 .HasOne(t => t.Week)
                 .WithMany(w => w.Timesheets)
                 .HasForeignKey(t => t.WeekId);
+
+            modelBuilder.Entity<Timesheet>()
+                .Property(t => t.Utilisation)
+                .HasPrecision(5, 4)
+                .HasDefaultValue(1.0);
 
             modelBuilder.Entity<Trade>()
                 .HasIndex(t => t.Description)

--- a/BonusCalcListener/Infrastructure/Operative.cs
+++ b/BonusCalcListener/Infrastructure/Operative.cs
@@ -13,6 +13,9 @@ namespace BonusCalcListener.Infrastructure
         [StringLength(100)]
         public string Name { get; set; }
 
+        [StringLength(100)]
+        public string EmailAddress { get; set; }
+
         [Required]
         [StringLength(3)]
         public string TradeId { get; set; }
@@ -26,6 +29,8 @@ namespace BonusCalcListener.Infrastructure
         public string Section { get; set; }
 
         public int SalaryBand { get; set; }
+
+        public decimal Utilisation { get; set; }
 
         public bool FixedBand { get; set; }
 

--- a/BonusCalcListener/Infrastructure/PayElement.cs
+++ b/BonusCalcListener/Infrastructure/PayElement.cs
@@ -8,7 +8,9 @@ namespace BonusCalcListener.Infrastructure
         [Key]
         public int Id { get; set; }
 
-        public int TimesheetId { get; set; }
+        [Required]
+        [StringLength(17)]
+        public string TimesheetId { get; set; }
         public Timesheet Timesheet { get; set; }
 
         public int PayElementTypeId { get; set; }
@@ -34,23 +36,5 @@ namespace BonusCalcListener.Infrastructure
         public decimal Value { get; set; }
         public bool ReadOnly { get; set; }
         public DateTime? ClosedAt { get; set; }
-
-        public void UpdateFrom(PayElementUpdate payElement)
-        {
-            Address = payElement.Address;
-            Comment = payElement.Comment;
-            Monday = payElement.Monday;
-            Tuesday = payElement.Tuesday;
-            Wednesday = payElement.Wednesday;
-            Thursday = payElement.Thursday;
-            Friday = payElement.Friday;
-            Saturday = payElement.Saturday;
-            Sunday = payElement.Sunday;
-            Duration = payElement.Duration;
-            Value = payElement.Value;
-            WorkOrder = payElement.WorkOrder;
-            PayElementTypeId = payElement.PayElementTypeId;
-            ClosedAt = payElement.ClosedAt;
-        }
     }
 }

--- a/BonusCalcListener/Infrastructure/PayElementType.cs
+++ b/BonusCalcListener/Infrastructure/PayElementType.cs
@@ -22,6 +22,12 @@ namespace BonusCalcListener.Infrastructure
 
         public bool Adjustment { get; set; }
 
+        public bool OutOfHours { get; set; }
+
+        public bool Overtime { get; set; }
+
+        public bool Selectable { get; set; }
+
         public List<PayElement> PayElements { get; set; }
     }
 }

--- a/BonusCalcListener/Infrastructure/Timesheet.cs
+++ b/BonusCalcListener/Infrastructure/Timesheet.cs
@@ -6,7 +6,8 @@ namespace BonusCalcListener.Infrastructure
     public class Timesheet
     {
         [Key]
-        public int Id { get; set; }
+        [StringLength(17)]
+        public string Id { get; set; }
 
         [Required]
         [StringLength(6)]
@@ -15,6 +16,8 @@ namespace BonusCalcListener.Infrastructure
 
         public string WeekId { get; set; }
         public Week Week { get; set; }
+
+        public decimal Utilisation { get; set; }
 
         public List<PayElement> PayElements { get; set; }
     }

--- a/BonusCalcListener/RepairsEventTypes.cs
+++ b/BonusCalcListener/RepairsEventTypes.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace BonusCalcListener
 {
     public static class RepairsEventTypes

--- a/BonusCalcListener/RepairsStatusCodes.cs
+++ b/BonusCalcListener/RepairsStatusCodes.cs
@@ -1,0 +1,9 @@
+namespace BonusCalcListener
+{
+    public static class RepairsStatusCodes
+    {
+        public const int Cancelled = 30;
+        public const int Completed = 50;
+        public const int NoAccess = 1000;
+    }
+}

--- a/BonusCalcListener/UseCase/PayElementMapper.cs
+++ b/BonusCalcListener/UseCase/PayElementMapper.cs
@@ -7,7 +7,6 @@ namespace BonusCalcListener.UseCase
     public class PayElementMapper : IMapPayElements
     {
         const int REACTIVE_REPAIRS_TYPE = 301;
-        const int COMPLETED_STATUS = 50;
 
         public PayElement BuildPayElement(WorkOrderOperativeSmvData eventData, Timesheet operativeTimesheet)
         {
@@ -18,7 +17,7 @@ namespace BonusCalcListener.UseCase
 
             if (!eventData.JobPercentage.HasValue || eventData.JobPercentage <= 0) throw new ArgumentException($"Cannot have a job percentage of zero or less than zero, WorkOrder: {eventData.WorkOrderId}");
 
-            if (eventData.WorkOrderStatusCode == COMPLETED_STATUS)
+            if (eventData.WorkOrderStatusCode == RepairsStatusCodes.Completed)
             {
                 operativeJobSmvMinutes = (decimal) (eventData.StandardMinuteValue * eventData.JobPercentage / 100 ?? 0);
                 operativeJobSmvHours = operativeJobSmvMinutes / 60;

--- a/BonusCalcListener/UseCase/PayElementMapper.cs
+++ b/BonusCalcListener/UseCase/PayElementMapper.cs
@@ -7,23 +7,31 @@ namespace BonusCalcListener.UseCase
     public class PayElementMapper : IMapPayElements
     {
         const int REACTIVE_REPAIRS_TYPE = 301;
+        const int COMPLETED_STATUS = 50;
+
         public PayElement BuildPayElement(WorkOrderOperativeSmvData eventData, Timesheet operativeTimesheet)
         {
+            var operativeJobSmvMinutes = 0.0m;
+            var operativeJobSmvHours = 0.0m;
+
             if (!eventData.ClosedTime.HasValue) throw new ArgumentException($"Cannot create a pay element with null closed time, WorkOrder: {eventData.WorkOrderId}, operative: {eventData.OperativePrn}");
 
             if (!eventData.JobPercentage.HasValue || eventData.JobPercentage <= 0) throw new ArgumentException($"Cannot have a job percentage of zero or less than zero, WorkOrder: {eventData.WorkOrderId}");
 
-            var operativeJobSmvMinutes = (decimal) (eventData.StandardMinuteValue * eventData.JobPercentage ?? 0);
-            var operativeJobSmvHours = operativeJobSmvMinutes / 60;
+            if (eventData.WorkOrderStatusCode == COMPLETED_STATUS)
+            {
+                operativeJobSmvMinutes = (decimal) (eventData.StandardMinuteValue * eventData.JobPercentage / 100 ?? 0);
+                operativeJobSmvHours = operativeJobSmvMinutes / 60;
+            }
 
             return new PayElement
             {
                 TimesheetId = operativeTimesheet.Id,
                 PayElementTypeId = REACTIVE_REPAIRS_TYPE,
-                Address = eventData.Address,
                 WorkOrder = eventData.WorkOrderId,
-                Duration = operativeJobSmvHours,
-                ReadOnly = true,
+                Address = eventData.Address,
+                Comment = eventData.Description,
+                ClosedAt = eventData.ClosedTime,
                 Monday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Monday ? operativeJobSmvHours : 0.0m,
                 Tuesday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Tuesday ? operativeJobSmvHours : 0.0m,
                 Wednesday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Wednesday ? operativeJobSmvHours : 0.0m,
@@ -31,9 +39,9 @@ namespace BonusCalcListener.UseCase
                 Friday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Friday ? operativeJobSmvHours : 0.0m,
                 Saturday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Saturday ? operativeJobSmvHours : 0.0m,
                 Sunday = eventData.ClosedTime.Value.DayOfWeek == DayOfWeek.Sunday ? operativeJobSmvHours : 0.0m,
-                Comment = eventData.Description,
+                Duration = operativeJobSmvHours,
                 Value = operativeJobSmvMinutes,
-                ClosedAt = eventData.ClosedTime
+                ReadOnly = true
             };
         }
     }

--- a/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
+++ b/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
@@ -19,7 +19,6 @@ namespace BonusCalcListener.UseCase
         private readonly ILogger<UpdateExistingWorkOrderPayElementsUseCase> _logger;
 
         const int REACTIVE_REPAIRS_PAY_ELEMENT_TYPE = 301;
-        const int CANCELLED_STATUS = 30;
 
         public UpdateExistingWorkOrderPayElementsUseCase(IPayElementGateway payElementGateway, ITimesheetGateway timesheetGateway, IMapPayElements payElementMapper, IDbSaver dbSaver, ILogger<UpdateExistingWorkOrderPayElementsUseCase> logger)
         {
@@ -57,7 +56,7 @@ namespace BonusCalcListener.UseCase
             }
 
             // Don't create a pay element if the work order was cancelled
-            if (data.WorkOrderStatusCode != CANCELLED_STATUS)
+            if (data.WorkOrderStatusCode != RepairsStatusCodes.Cancelled)
             {
                 //3a. Create pay element
                 var npe = _payElementMapper.BuildPayElement(message.EventData, operativeTimesheet);

--- a/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
+++ b/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
@@ -46,7 +46,7 @@ namespace BonusCalcListener.UseCase
             _logger.LogInformation($"Found timesheet {operativeTimesheet.Id} for {data.WorkOrderId}");
 
             //1b. Get the work order (if any) from the database
-            var existingPayElementCollection = (await _payElementGateway.GetPayElementsByWorkOrderId(data.WorkOrderId, REACTIVE_REPAIRS_PAY_ELEMENT_TYPE)).ToList();
+            var existingPayElementCollection = await _payElementGateway.GetPayElementsByWorkOrderId(data.WorkOrderId, REACTIVE_REPAIRS_PAY_ELEMENT_TYPE);
 
             //2. If any have been found, remove them
             if (existingPayElementCollection.Any())

--- a/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
+++ b/BonusCalcListener/UseCase/UpdateExistingWorkOrderPayElementsUseCase.cs
@@ -55,8 +55,8 @@ namespace BonusCalcListener.UseCase
                 existingPayElementCollection.Clear();
             }
 
-            // Don't create a pay element if the work order was cancelled
-            if (data.WorkOrderStatusCode != RepairsStatusCodes.Cancelled)
+            // Only create a pay element if the work order was completed or is no access
+            if (data.WorkOrderStatusCode == RepairsStatusCodes.Completed || data.WorkOrderStatusCode == RepairsStatusCodes.NoAccess)
             {
                 //3a. Create pay element
                 var npe = _payElementMapper.BuildPayElement(message.EventData, operativeTimesheet);


### PR DESCRIPTION
* Update schema to latest version with string timesheet id
* Fix issue where percentage wasn't calculated correctly
* Don't award SMVs for work orders that were closed with 'No Access'
* Don't insert pay element for work orders that were cancelled
