### PR TITLE
Fix namespacing for gateways and interfaces

### DIFF
--- a/BonusCalcListener/Gateway/Interfaces/IPayElementGateway.cs
+++ b/BonusCalcListener/Gateway/Interfaces/IPayElementGateway.cs
@@ -1,10 +1,8 @@
-using BonusCalcListener.Boundary;
 using BonusCalcListener.Infrastructure;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace BonusCalcListener.Gateway
+namespace BonusCalcListener.Gateway.Interfaces
 {
     public interface IPayElementGateway
     {

--- a/BonusCalcListener/Gateway/PayElementGateway.cs
+++ b/BonusCalcListener/Gateway/PayElementGateway.cs
@@ -1,8 +1,9 @@
+using BonusCalcListener.Gateway.Interfaces;
 using BonusCalcListener.Infrastructure;
-using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 
 namespace BonusCalcListener.Gateway
 {

--- a/BonusCalcListener/Gateway/TimesheetGateway.cs
+++ b/BonusCalcListener/Gateway/TimesheetGateway.cs
@@ -1,3 +1,4 @@
+using BonusCalcListener.Gateway.Interfaces;
 using BonusCalcListener.Infrastructure;
 using System;
 using System.Threading.Tasks;
@@ -5,7 +6,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
-namespace BonusCalcListener.Gateway.Interfaces
+namespace BonusCalcListener.Gateway
 {
     public class TimesheetGateway : ITimesheetGateway
     {


### PR DESCRIPTION
Getting the following exception in the AWS X-Ray trace:

```
Unable to resolve service for type 'BonusCalcListener.Gateway.IPayElementGateway' 
while attempting to activate 'BonusCalcListener.UseCase.UpdateExistingWorkOrderPayElementsUseCase'
```