### PR TITLE
Use the timesheet from the week the job was closed

### DIFF
--- a/BonusCalcListener.Tests/Gateway/TimesheetGatewayTests.cs
+++ b/BonusCalcListener.Tests/Gateway/TimesheetGatewayTests.cs
@@ -1,0 +1,158 @@
+using BonusCalcListener.Gateway;
+using BonusCalcListener.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BonusCalcListener.Tests.Gateway
+{
+    public class TimesheetGatewayTests : DatabaseTests
+    {
+        private Mock<ILogger<TimesheetGateway>> _loggerMock;
+        private TimesheetGateway _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _loggerMock = new Mock<ILogger<TimesheetGateway>>();
+            _classUnderTest = new TimesheetGateway(BonusCalcContext, _loggerMock.Object);
+        }
+
+        [Test]
+        public async Task RetrievesCorrectTimesheetIfClosedInOpenWeek()
+        {
+            // Arrange
+            await SeedData();
+
+            // Act
+            var closedDate = new DateTime(2021, 10, 19, 11, 0, 0, DateTimeKind.Utc);
+            var result = await _classUnderTest.GetCurrentTimeSheetForOperative("123456", closedDate);
+
+            // Assert
+            result.Id.Should().Be("123456/2021-10-18");
+        }
+
+        [Test]
+        public async Task RetrievesCorrectTimesheetIfClosedInClosedWeek()
+        {
+            // Arrange
+            await SeedData();
+
+            // Act
+            var closedDate = new DateTime(2021, 10, 5, 11, 0, 0, DateTimeKind.Utc);
+            var result = await _classUnderTest.GetCurrentTimeSheetForOperative("123456", closedDate);
+
+            // Assert
+            result.Id.Should().Be("123456/2021-10-11");
+        }
+
+        private async Task SeedData()
+        {
+            var trade = new Trade
+            {
+                Id = "EL",
+                Description = "Electrician"
+            };
+
+            var scheme = new Scheme
+            {
+                Id = 1,
+                Type = "SMV",
+                Description = "Reactive",
+                ConversionFactor = 1.0M
+            };
+
+            var operative = new Operative
+            {
+                Id = "123456",
+                Name = "An Operative",
+                Trade = trade,
+                Scheme = scheme,
+                Section = "H3007",
+                SalaryBand = 5,
+                FixedBand = false,
+                IsArchived = false
+            };
+
+            var bonusPeriod = new BonusPeriod
+            {
+                Id = "2021-08-02",
+                StartAt = new DateTime(2021, 8, 1, 23, 0, 0, DateTimeKind.Utc),
+                Year = 2020,
+                Number = 3,
+                ClosedAt = null,
+                Weeks = new List<Week>()
+                {
+                    new Week
+                    {
+                        Id = "2021-10-04",
+                        StartAt = new DateTime(2021, 10, 3, 23, 0, 0, DateTimeKind.Utc),
+                        Number = 10,
+                        ClosedAt = new DateTime(2021, 10, 11, 16, 0, 0, DateTimeKind.Utc)
+                    },
+                    new Week
+                    {
+                        Id = "2021-10-11",
+                        StartAt = new DateTime(2021, 10, 10, 23, 0, 0, DateTimeKind.Utc),
+                        Number = 11,
+                        ClosedAt = null
+                    },
+                    new Week
+                    {
+                        Id = "2021-10-18",
+                        StartAt = new DateTime(2021, 10, 17, 23, 0, 0, DateTimeKind.Utc),
+                        Number = 12,
+                        ClosedAt = null
+                    },
+                    new Week
+                    {
+                        Id = "2021-10-25",
+                        StartAt = new DateTime(2021, 10, 24, 23, 0, 0, DateTimeKind.Utc),
+                        Number = 13,
+                        ClosedAt = null
+                    }
+                }
+            };
+
+            var timesheets = new List<Timesheet>()
+            {
+                new Timesheet
+                {
+                    Id = "123456/2021-10-04",
+                    OperativeId = "123456",
+                    WeekId = "2021-10-04"
+                },
+                new Timesheet
+                {
+                    Id = "123456/2021-10-11",
+                    OperativeId = "123456",
+                    WeekId = "2021-10-11"
+                },
+                new Timesheet
+                {
+                    Id = "123456/2021-10-18",
+                    OperativeId = "123456",
+                    WeekId = "2021-10-18"
+                },
+                new Timesheet
+                {
+                    Id = "123456/2021-10-25",
+                    OperativeId = "123456",
+                    WeekId = "2021-10-25"
+                },
+            };
+
+            await BonusCalcContext.Trades.AddAsync(trade);
+            await BonusCalcContext.Schemes.AddAsync(scheme);
+            await BonusCalcContext.Operatives.AddAsync(operative);
+            await BonusCalcContext.BonusPeriods.AddAsync(bonusPeriod);
+            await BonusCalcContext.Timesheets.AddRangeAsync(timesheets);
+            await BonusCalcContext.SaveChangesAsync();
+        }
+    }
+}

--- a/BonusCalcListener/Gateway/TimesheetGateway.cs
+++ b/BonusCalcListener/Gateway/TimesheetGateway.cs
@@ -23,8 +23,10 @@ namespace BonusCalcListener.Gateway
         {
             if (!closedTime.HasValue) throw new ArgumentNullException(nameof(closedTime));
 
+            var weekStart = WeekStartForClosedTime(closedTime);
+
             var week = await _context.Weeks
-                .Where(w => w.StartAt <= closedTime)
+                .Where(w => w.StartAt >= weekStart)
                 .Where(w => w.ClosedAt == null)
                 .OrderBy(w => w.StartAt)
                 .FirstOrDefaultAsync();
@@ -42,6 +44,19 @@ namespace BonusCalcListener.Gateway
                 .Include(t => t.Operative)
                 .Where(x => x.OperativeId == operativeId && x.WeekId == week.Id)
                 .SingleOrDefaultAsync();
+        }
+
+        private DateTime WeekStartForClosedTime(DateTime? closedTime)
+        {
+            // Convert the UTC timestamp to GMT/BST at the beginning of the day
+            var closedDate = (((DateTime) closedTime).ToLocalTime()).Date;
+
+            // Calculate the number of days we need to subtract to get back to Monday
+            var startOfWeek = (int) DayOfWeek.Monday;
+            var daysSinceStartOfWeek = ((int) closedDate.DayOfWeek + 7 - startOfWeek) % 7;
+
+            // Convert back to UTC after subtracting the days for the database
+            return closedDate.AddDays(-daysSinceStartOfWeek).ToUniversalTime();
         }
     }
 }

--- a/BonusCalcListener/serverless.yml
+++ b/BonusCalcListener/serverless.yml
@@ -24,6 +24,7 @@ functions:
       ENVIRONMENT:  ${ssm:/housing-tl/${self:provider.stage}/aspnetcore-environment}
       ### Reuse existing connection string from API (already definied in SSM)
       CONNECTION_STRING: Host=${ssm:/bonuscalc-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/bonuscalc-api/${self:provider.stage}/postgres-port};Database=${ssm:/bonuscalc-api/${self:provider.stage}/postgres-database};Username=${ssm:/bonuscalc-api/${self:provider.stage}/postgres-username};Password=${ssm:/bonuscalc-api/${self:provider.stage}/postgres-password}
+      TZ: Europe/London
     events:
       ### Specify the parameter containing the queue arn used to trigget the lambda function here
       ### This will have been defined in the terraform configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,10 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword
       - DB_DATABASE=testdb
+      - TZ=Europe/London
     depends_on:
       - test-database
-  
+
   test-database:
     image: postgres:12
     ports:


### PR DESCRIPTION
Either that or the first open week after the job was closed and not the earliest available week otherwise when we turn it on jobs would get put into the first week as none of them are closed yet.
