### PR TITLE
Small - set Xray TraceID if available

### DIFF
--- a/BonusCalcListener/BaseFunction.cs
+++ b/BonusCalcListener/BaseFunction.cs
@@ -1,3 +1,5 @@
+using Amazon.XRay.Recorder.Core;
+using Amazon.XRay.Recorder.Core.Strategies;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using BonusCalcListener.Infrastructure;
 using Hackney.Core.Logging;
@@ -36,6 +38,10 @@ namespace BonusCalcListener
 
             Configure(builder);
             Configuration = builder.Build();
+
+            AWSXRayRecorder.InitializeInstance(Configuration);
+            AWSXRayRecorder.Instance.ContextMissingStrategy = ContextMissingStrategy.LOG_ERROR;
+
             services.AddSingleton<IConfiguration>(Configuration);
 
             services.ConfigureLambdaLogging(Configuration);

--- a/BonusCalcListener/SqsFunction.cs
+++ b/BonusCalcListener/SqsFunction.cs
@@ -1,5 +1,6 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.SQSEvents;
+using Amazon.XRay.Recorder.Core.Internal.Entities;
 using BonusCalcListener.Boundary;
 using BonusCalcListener.Factories;
 using BonusCalcListener.Gateway;
@@ -83,7 +84,9 @@ namespace BonusCalcListener
 
             var entityEvent = JsonSerializer.Deserialize<EntityEventSns>(message.Body, _jsonOptions);
 
-            using (Logger.BeginScope("CorrelationId: {CorrelationId}", entityEvent.CorrelationId))
+            var traceUsingXray = message.Attributes.TryGetValue("AWSTraceHeader", out string traceHeader);
+
+            using (Logger.BeginScope("CorrelationId: {CorrelationId}", traceUsingXray ? TraceHeader.FromString(traceHeader).RootTraceId : Guid.NewGuid().ToString()))
             {
                 try
                 {


### PR DESCRIPTION
This is a little messy because the AWS [documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-dotnet-messagehandler.html) is based around ASP.NET Core - we obviously don't have access to the IWebHostBuilder here - however there is an example [here](https://docs.aws.amazon.com/xray/latest/devguide/xray-services-sqs.html) which this is based on